### PR TITLE
Remove Task.Delay after operation is performed

### DIFF
--- a/src/DistributedLock.AzureStorage/AzureStorageDistributedLock.cs
+++ b/src/DistributedLock.AzureStorage/AzureStorageDistributedLock.cs
@@ -99,8 +99,11 @@ namespace DistributedLocks.AzureStorage
                     {
                         await ReleaseLeaseAsync(lease).ConfigureAwait(false);
                     }
-
-                    await Task.Delay(Options.RetryWaitTime).ConfigureAwait(false);
+                    
+                    if (!operationPerformed)
+                    {
+                        await Task.Delay(Options.RetryWaitTime).ConfigureAwait(false);
+                    }
                 }
 
                 return value;


### PR DESCRIPTION
small update to avoid unnecessary waiting when operation succeeded