### PR TITLE
Fix for Nuget package 1.0.1 of DistributedLocks.AzureStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ For more examples please check samples folder in the repo.
 ## <a name="versions"> Versions </a>
 
 - v1.0.0: Uses Microsoft.Azure.Storage.Blob v9.4.2
-- v1.0.1: Uses Microsoft.Azure.Storage.Blob v10.0.3 which has breaking changes because namespaces changed
+- v1.0.2: Uses Microsoft.Azure.Storage.Blob v10.0.3 which has breaking changes because namespaces changed
 
 ## <a name="license"> License </a>
 

--- a/src/DistributedLock.AzureStorage/DistributedLocks.AzureStorage.csproj
+++ b/src/DistributedLock.AzureStorage/DistributedLocks.AzureStorage.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
         <PackageId>DistributedLocks.AzureStorage</PackageId>
-        <PackageVersion>1.0.1</PackageVersion>
+        <PackageVersion>1.0.2</PackageVersion>
         <Authors>David Revoledo (Deivit)</Authors>
         <Owners>David Revoledo</Owners>
         <PackageProjectUrl>https://github.com/davidrevoledo/DistributedLocks</PackageProjectUrl>
@@ -12,7 +12,7 @@
         <PackageReleaseNotes>Update to Microsoft.Azure.Storage.Blob v10.0.3 which has breaking changes because namespaces have been changed</PackageReleaseNotes>
         <Copyright>Copyright 2018 (c) DistributedLock is licensed under the MIT License.</Copyright>
         <PackageTags>Cloud DistributedComputing Azure AzureStorage Locking Microservices CompetingNodes</PackageTags>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <AssemblyName>DistributedLock.AzureStorage</AssemblyName>
     </PropertyGroup>
 

--- a/src/DistributedLock/DistributedLocks.csproj
+++ b/src/DistributedLock/DistributedLocks.csproj
@@ -12,7 +12,7 @@
         <PackageReleaseNotes>Initial commit.</PackageReleaseNotes>
         <Copyright>Copyright 2018 (c) DistributedLock is licensed under the MIT License.</Copyright>
         <PackageTags>Cloud DistributedComputing Azure AzureStorage Locking Microservices CompetingNodes</PackageTags>
-        <Version>1.0.1</Version>
+        <Version>1.0.0</Version>
         <AssemblyName>DistributedLock</AssemblyName>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
I made a mistake by increasing the DistributedLock project version. The result is that the Nuget package of DistributedLocks.AzureStorage 1.0.1 was looking for version 1.0.1 of DistributedLock which does not exist. So the fix is to set version of DistributedLocks back to 1.0.0 (nothing is changed) and increasing DistributedLocks.AzureStorage to 1.0.2